### PR TITLE
add links to plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -17,7 +17,11 @@
       "small": "img/rabbitmq_logo.svg",
       "large": "img/rabbitmq_logo.svg"
     },
-    "links": [],
+    "links": [
+      { "name": "License", "url": "https://github.com/maor-mil/maormil-rabbitmq-datasource/blob/main/LICENSE" },
+      { "name": "raise issue", "url": "https://github.com/maor-mil/maormil-rabbitmq-datasource/issues/new" },
+      { "name": "repository", "url": "https://github.com/maor-mil/maormil-rabbitmq-datasource" }
+    ],
     "screenshots": [
       {
         "name": "New RabbitMQ Datasource",


### PR DESCRIPTION
Hi there 👋 

This PR adds missing metadata to allow Grafana to render appropriate links from the catalog page for the data source back to the source repo. 

This will hopefully make it easier for users to engage with the project and provide feedback/PRs

Docs: https://grafana.com/developers/plugin-tools/reference/plugin-json#links

Example: bottom right of this screenshot of the github data source
<img width="1474" alt="Screenshot 2025-04-07 at 12 24 32" src="https://github.com/user-attachments/assets/b67fdc21-86be-460e-98de-bf7820eedb27" />
